### PR TITLE
Added account type selection and logout confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
         "react-is": "^18.3.1",
+        "react-router-dom": "^7.8.2",
         "styled-components": "^6.1.19"
       },
       "devDependencies": {
@@ -3193,6 +3194,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -4649,6 +4659,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -4834,6 +4882,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -5411,21 +5465,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@mui/styled-engine-sc": "^7.3.2",
+    "typescript": "^5.4.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
     "react-is": "^18.3.1",
+    "react-router-dom": "^7.8.2",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,84 +1,17 @@
-import { useState } from "react";
-import viteLogo from "/chat.svg";
-import "./App.scss";
-import { HomePage } from "./common/labelConstants";
+import React from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import AccountTypeSelection from "./pages/AccountTypeSelection";
+import LoggedOut from "./pages/LoggedOut";
 
-// ✅ MUI imports
-import {
-  Box,
-  Card,
-  CardContent,
-  Typography,
-  Button,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  ListItemButton,
-} from "@mui/material";
-
-// ✅ MUI icons
-import HomeIcon from "@mui/icons-material/Home";
-import PersonIcon from "@mui/icons-material/Person";
-import SettingsIcon from "@mui/icons-material/Settings";
-
-function App() {
-  const [count, setCount] = useState(0);
-
-  // Items with label + MUI icon
-  const items = [
-    { label: "Home", icon: <HomeIcon /> },
-    { label: "Profile", icon: <PersonIcon /> },
-    { label: "Settings", icon: <SettingsIcon /> },
-  ];
-
+const App: React.FC = () => {
   return (
-    <Box p={3}>
-      {/* Logo */}
-      <Box mb={2}>
-        <a href="https://vite.dev" target="_blank" rel="noreferrer">
-          <img src={viteLogo} alt="Vite logo" style={{ width: 60 }} />
-        </a>
-      </Box>
-
-      {/* Heading */}
-      <Typography variant="h4" className="heading" gutterBottom>
-        {HomePage.VITE} + {HomePage.REACT}
-      </Typography>
-
-      {/* Iterated list */}
-      <Card sx={{ mb: 3 }}>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Menu
-          </Typography>
-          <List>
-            {items.map((item, index) => (
-              <ListItem key={index} >
-                <ListItemButton>
-                <ListItemIcon>{item.icon}</ListItemIcon>
-                <ListItemText primary={item.label} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-        </CardContent>
-      </Card>
-
-      {/* Counter Button */}
-      <Card>
-        <CardContent>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={() => setCount((c) => c + 1)}
-          >
-            Count is {count}
-          </Button>
-        </CardContent>
-      </Card>
-    </Box>
+    <Router>
+      <Routes>
+        <Route path="/" element={<AccountTypeSelection />} />
+        <Route path="/logged-out" element={<LoggedOut />} />
+      </Routes>
+    </Router>
   );
-}
+};
 
 export default App;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,13 @@
+// common/constants.ts
+
+export const LABELS = {
+  WELCOME_TEXT: "Hello, welcome to",
+  COMPANY_NAME: "Cerebro SASA",
+  SELECT_PROMPT: "Please select an account type to proceed:",
+  ACCOUNT_TYPE: "Account Type",
+  PROCEED_BUTTON: "Proceed →",
+  LOGOUT_CONFIRM_TITLE: "Confirm Logout",
+  LOGOUT_CONFIRM_MESSAGE: "Are you sure you want to log out?",
+  CANCEL_BUTTON: "Cancel",
+  LOGOUT_BUTTON: "Logout",
+};

--- a/src/common/dropdowns.tsx
+++ b/src/common/dropdowns.tsx
@@ -1,0 +1,23 @@
+// common/dropdowns.ts
+
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import BuildCircleIcon from "@mui/icons-material/BuildCircle";
+import CodeIcon from "@mui/icons-material/Code";
+
+export const roles = [
+  {
+    value: "Admin",
+    label: "Admin",
+    icon: <AdminPanelSettingsIcon sx={{ color: "#9b57f5" }} />,
+  },
+  {
+    value: "Technical",
+    label: "Technical",
+    icon: <BuildCircleIcon sx={{ color: "#00bcd4" }} />,
+  },
+  {
+    value: "Developer",
+    label: "Developer",
+    icon: <CodeIcon sx={{ color: "#4caf50" }} />,
+  },
+];

--- a/src/common/labelConstants.tsx
+++ b/src/common/labelConstants.tsx
@@ -1,19 +1,35 @@
+// src/common/labelConstants.tsx
 
 export const HomePage = {
-    AIFA : 'AIFA',
-    VITE : "Vite",
-    REACT : "React"
-}
+  AIFA: "AIFA",
+  VITE: "Vite",
+  REACT: "React",
+};
 
 export const HomePage_Dropdowns = {
-    ADMIN: 'Admin',
-    TECHNICAL : 'Technical',
-    TRAINING : 'Training',
-    HR : 'HR',
-}
+  ADMIN: "Admin",
+  TECHNICAL: "Technical",
+  TRAINING: "Training",
+  HR: "HR",
+};
 
+export const AccountSelection = {
+  WELCOME: "Hello, welcome to",
+  PLATFORM_NAME: "Cerebro SASA",
+  SELECT_PROMPT: "Please select an account type to proceed:",
+  ACCOUNT_TYPE_LABEL: "Account Type",
+  PROCEED_BUTTON: "Proceed →",
+};
 
-// If you want to use this variables in your component
-// Example:
-// import { HomePage } from 'src/common/labelConstants';
-// <Typography>{HomePage.AIFA}}</Typography>
+export const LogoutDialog = {
+  CONFIRM_TITLE: "Confirm Logout",
+  CONFIRM_MESSAGE: "Are you sure you want to log out?",
+  CANCEL_BUTTON: "Cancel",
+  LOGOUT_BUTTON: "Logout",
+};
+
+export const LoggedOutPage = {
+  TITLE: "You’ve been logged out",
+  DESCRIPTION: "Click to return to the homepage",
+  RETURN_HOME: "Return to Home",
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,13 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css"; // or App.scss if you want
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
     <App />
-  </StrictMode>,
-)
+  </React.StrictMode>
+);

--- a/src/pages/AccountTypeSelection.tsx
+++ b/src/pages/AccountTypeSelection.tsx
@@ -16,33 +16,12 @@ import {
   DialogContentText,
   DialogActions,
 } from "@mui/material";
-
 import { useNavigate } from "react-router-dom";
-
-import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
-import BuildCircleIcon from "@mui/icons-material/BuildCircle";
-import CodeIcon from "@mui/icons-material/Code";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import LogoutIcon from "@mui/icons-material/Logout";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
-
-const roles = [
-  {
-    value: "Admin",
-    label: "Admin",
-    icon: <AdminPanelSettingsIcon sx={{ color: "#9b57f5" }} />,
-  },
-  {
-    value: "Technical",
-    label: "Technical",
-    icon: <BuildCircleIcon sx={{ color: "#00bcd4" }} />,
-  },
-  {
-    value: "Developer",
-    label: "Developer",
-    icon: <CodeIcon sx={{ color: "#4caf50" }} />,
-  },
-];
+import { roles } from "../common/dropdowns";
+import { AccountSelection, LogoutDialog } from "../common/labelConstants";
 
 const AccountTypeSelection: React.FC = () => {
   const [accountType, setAccountType] = useState("Admin");
@@ -61,12 +40,12 @@ const AccountTypeSelection: React.FC = () => {
 
   const handleLogout = () => {
     handleCloseMenu();
-    setLogoutConfirmOpen(true); // Open the confirmation dialog
+    setLogoutConfirmOpen(true);
   };
 
   const confirmLogout = () => {
     setLogoutConfirmOpen(false);
-    navigate("/logged-out"); // Redirect to logout page
+    navigate("/logged-out");
   };
 
   const cancelLogout = () => {
@@ -76,8 +55,6 @@ const AccountTypeSelection: React.FC = () => {
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setAccountType(event.target.value as string);
   };
-
-
 
   const handleProceed = () => {
     alert(`Proceeding as: ${accountType}`);
@@ -96,27 +73,15 @@ const AccountTypeSelection: React.FC = () => {
             paddingRight: 2,
           }}
         >
-          {/* LEFT: Chat icon and title */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <img src="/chat.svg" alt="Chat Icon" style={{ width: 20, height: 20 }} />
-            <Typography
-              variant="h6"
-              sx={{ fontWeight: "600", color: "#fff", userSelect: "none" }}
-            >
+            <Typography variant="h6" sx={{ fontWeight: "600", color: "#fff" }}>
               AiFA
             </Typography>
           </Box>
 
-          {/* RIGHT: Swap icon and profile box */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-            <SwapHorizIcon
-              sx={{
-                color: "#fff",
-                fontSize: 28,
-                cursor: "pointer",
-                userSelect: "none",
-              }}
-            />
+            <SwapHorizIcon sx={{ color: "#fff", fontSize: 28, cursor: "pointer" }} />
 
             <Box
               sx={{
@@ -134,15 +99,9 @@ const AccountTypeSelection: React.FC = () => {
                 alt="AIFA Logo"
                 style={{ width: 90, height: 40, objectFit: "contain" }}
               />
-
               <IconButton
                 onClick={handleProfileClick}
-                sx={{
-                  bgcolor: "#fff",
-                  borderRadius: "50%",
-                  p: 0.5,
-                  ml: 0.5,
-                }}
+                sx={{ bgcolor: "#fff", borderRadius: "50%", p: 0.5, ml: 0.5 }}
               >
                 <AccountCircleIcon sx={{ fontSize: 32, color: "#906aff" }} />
               </IconButton>
@@ -160,8 +119,6 @@ const AccountTypeSelection: React.FC = () => {
                 borderRadius: 3,
                 mt: 1,
                 minWidth: 150,
-                boxShadow:
-                  "0px 4px 6px rgba(0, 0, 0, 0.1), 0px 1px 3px rgba(0, 0, 0, 0.06)",
               },
             }}
             anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
@@ -182,7 +139,7 @@ const AccountTypeSelection: React.FC = () => {
               }}
             >
               <LogoutIcon fontSize="medium" />
-              Logout
+              {LogoutDialog.LOGOUT_BUTTON}
             </MenuItem>
           </Menu>
         </Toolbar>
@@ -190,33 +147,31 @@ const AccountTypeSelection: React.FC = () => {
 
       {/* Logout Confirmation Dialog */}
       <Dialog open={logoutConfirmOpen} onClose={cancelLogout}>
-        <DialogTitle>Confirm Logout</DialogTitle>
+        <DialogTitle>{LogoutDialog.CONFIRM_TITLE}</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            Are you sure you want to log out?
-          </DialogContentText>
+          <DialogContentText>{LogoutDialog.CONFIRM_MESSAGE}</DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button
-  onClick={cancelLogout}
-  sx={{
-    color: "#906aff",
-    fontWeight: "bold",
-    textTransform: "none",
-    border: "1px solid #906aff",
-    borderRadius: 2,
-    px: 2,
-    "&:hover": {
-      backgroundColor: "#f1ecff",
-      borderColor: "#ac8fff",
-    },
-  }}
->
-  Cancel
-</Button>
+            onClick={cancelLogout}
+            sx={{
+              color: "#906aff",
+              fontWeight: "bold",
+              textTransform: "none",
+              border: "1px solid #906aff",
+              borderRadius: 2,
+              px: 2,
+              "&:hover": {
+                backgroundColor: "#f1ecff",
+                borderColor: "#ac8fff",
+              },
+            }}
+          >
+            {LogoutDialog.CANCEL_BUTTON}
+          </Button>
 
           <Button onClick={confirmLogout} color="error" variant="contained">
-            Logout
+            {LogoutDialog.LOGOUT_BUTTON}
           </Button>
         </DialogActions>
       </Dialog>
@@ -234,21 +189,18 @@ const AccountTypeSelection: React.FC = () => {
       >
         <Box sx={{ maxWidth: 400, width: "100%" }}>
           <Typography variant="body1" mb={1} sx={{ color: "#000000" }}>
-            Hello, welcome to{" "}
+            {AccountSelection.WELCOME}{" "}
             <Typography component="span" sx={{ fontWeight: 600, color: "#906aff" }}>
-              Cerebro SASA
+              {AccountSelection.PLATFORM_NAME}
             </Typography>
           </Typography>
 
           <Typography variant="body2" mb={2} sx={{ color: "#000000" }}>
-            Please select an account type to proceed:
+            {AccountSelection.SELECT_PROMPT}
           </Typography>
 
-          <Typography
-            variant="subtitle2"
-            sx={{ textAlign: "left", mb: 1, fontWeight: 600 }}
-          >
-            Account Type
+          <Typography variant="subtitle2" sx={{ textAlign: "left", mb: 1, fontWeight: 600 }}>
+            {AccountSelection.ACCOUNT_TYPE_LABEL}
           </Typography>
 
           <FormControl fullWidth sx={{ mb: 3 }}>
@@ -259,15 +211,9 @@ const AccountTypeSelection: React.FC = () => {
                 borderRadius: 2,
                 border: "2px solid #906aff",
                 backgroundColor: "#fff",
-                ".MuiOutlinedInput-notchedOutline": {
-                  border: "none",
-                },
-                "&:hover .MuiOutlinedInput-notchedOutline": {
-                  border: "none",
-                },
-                "& .MuiSelect-icon": {
-                  color: "#906aff",
-                },
+                ".MuiOutlinedInput-notchedOutline": { border: "none" },
+                "&:hover .MuiOutlinedInput-notchedOutline": { border: "none" },
+                "& .MuiSelect-icon": { color: "#906aff" },
               }}
             >
               {roles.map((role) => (
@@ -293,7 +239,7 @@ const AccountTypeSelection: React.FC = () => {
               borderRadius: 10,
             }}
           >
-            Proceed →
+            {AccountSelection.PROCEED_BUTTON}
           </Button>
         </Box>
       </Box>

--- a/src/pages/AccountTypeSelection.tsx
+++ b/src/pages/AccountTypeSelection.tsx
@@ -1,0 +1,304 @@
+import React, { useState } from "react";
+import {
+  AppBar,
+  Toolbar,
+  IconButton,
+  Typography,
+  Box,
+  Button,
+  Select,
+  MenuItem,
+  FormControl,
+  Menu,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from "@mui/material";
+
+import { useNavigate } from "react-router-dom";
+
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import BuildCircleIcon from "@mui/icons-material/BuildCircle";
+import CodeIcon from "@mui/icons-material/Code";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import LogoutIcon from "@mui/icons-material/Logout";
+import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
+
+const roles = [
+  {
+    value: "Admin",
+    label: "Admin",
+    icon: <AdminPanelSettingsIcon sx={{ color: "#9b57f5" }} />,
+  },
+  {
+    value: "Technical",
+    label: "Technical",
+    icon: <BuildCircleIcon sx={{ color: "#00bcd4" }} />,
+  },
+  {
+    value: "Developer",
+    label: "Developer",
+    icon: <CodeIcon sx={{ color: "#4caf50" }} />,
+  },
+];
+
+const AccountTypeSelection: React.FC = () => {
+  const [accountType, setAccountType] = useState("Admin");
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
+  const openMenu = Boolean(anchorEl);
+  const navigate = useNavigate();
+
+  const handleProfileClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    handleCloseMenu();
+    setLogoutConfirmOpen(true); // Open the confirmation dialog
+  };
+
+  const confirmLogout = () => {
+    setLogoutConfirmOpen(false);
+    navigate("/logged-out"); // Redirect to logout page
+  };
+
+  const cancelLogout = () => {
+    setLogoutConfirmOpen(false);
+  };
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setAccountType(event.target.value as string);
+  };
+
+
+
+  const handleProceed = () => {
+    alert(`Proceeding as: ${accountType}`);
+  };
+
+  return (
+    <>
+      {/* Header */}
+      <AppBar position="static" sx={{ bgcolor: "#906aff", borderRadius: 0 }}>
+        <Toolbar
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingLeft: 2,
+            paddingRight: 2,
+          }}
+        >
+          {/* LEFT: Chat icon and title */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <img src="/chat.svg" alt="Chat Icon" style={{ width: 20, height: 20 }} />
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: "600", color: "#fff", userSelect: "none" }}
+            >
+              AiFA
+            </Typography>
+          </Box>
+
+          {/* RIGHT: Swap icon and profile box */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+            <SwapHorizIcon
+              sx={{
+                color: "#fff",
+                fontSize: 28,
+                cursor: "pointer",
+                userSelect: "none",
+              }}
+            />
+
+            <Box
+              sx={{
+                bgcolor: "#fff",
+                borderRadius: 3,
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                px: 2,
+                py: 0.5,
+              }}
+            >
+              <img
+                src="/aifa_clr_logo.svg"
+                alt="AIFA Logo"
+                style={{ width: 90, height: 40, objectFit: "contain" }}
+              />
+
+              <IconButton
+                onClick={handleProfileClick}
+                sx={{
+                  bgcolor: "#fff",
+                  borderRadius: "50%",
+                  p: 0.5,
+                  ml: 0.5,
+                }}
+              >
+                <AccountCircleIcon sx={{ fontSize: 32, color: "#906aff" }} />
+              </IconButton>
+            </Box>
+          </Box>
+
+          {/* Profile Menu */}
+          <Menu
+            anchorEl={anchorEl}
+            open={openMenu}
+            onClose={handleCloseMenu}
+            PaperProps={{
+              elevation: 8,
+              sx: {
+                borderRadius: 3,
+                mt: 1,
+                minWidth: 150,
+                boxShadow:
+                  "0px 4px 6px rgba(0, 0, 0, 0.1), 0px 1px 3px rgba(0, 0, 0, 0.06)",
+              },
+            }}
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            transformOrigin={{ vertical: "top", horizontal: "right" }}
+          >
+            <MenuItem
+              onClick={handleLogout}
+              sx={{
+                borderRadius: 3,
+                px: 3,
+                py: 1.5,
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                color: "#000",
+                fontWeight: "600",
+                fontSize: "1rem",
+              }}
+            >
+              <LogoutIcon fontSize="medium" />
+              Logout
+            </MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+
+      {/* Logout Confirmation Dialog */}
+      <Dialog open={logoutConfirmOpen} onClose={cancelLogout}>
+        <DialogTitle>Confirm Logout</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to log out?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+  onClick={cancelLogout}
+  sx={{
+    color: "#906aff",
+    fontWeight: "bold",
+    textTransform: "none",
+    border: "1px solid #906aff",
+    borderRadius: 2,
+    px: 2,
+    "&:hover": {
+      backgroundColor: "#f1ecff",
+      borderColor: "#ac8fff",
+    },
+  }}
+>
+  Cancel
+</Button>
+
+          <Button onClick={confirmLogout} color="error" variant="contained">
+            Logout
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Center Content */}
+      <Box
+        sx={{
+          minHeight: "calc(100vh - 64px)",
+          backgroundColor: "#f8f9fa",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          px: 3,
+        }}
+      >
+        <Box sx={{ maxWidth: 400, width: "100%" }}>
+          <Typography variant="body1" mb={1} sx={{ color: "#000000" }}>
+            Hello, welcome to{" "}
+            <Typography component="span" sx={{ fontWeight: 600, color: "#906aff" }}>
+              Cerebro SASA
+            </Typography>
+          </Typography>
+
+          <Typography variant="body2" mb={2} sx={{ color: "#000000" }}>
+            Please select an account type to proceed:
+          </Typography>
+
+          <Typography
+            variant="subtitle2"
+            sx={{ textAlign: "left", mb: 1, fontWeight: 600 }}
+          >
+            Account Type
+          </Typography>
+
+          <FormControl fullWidth sx={{ mb: 3 }}>
+            <Select
+              value={accountType}
+              onChange={handleChange}
+              sx={{
+                borderRadius: 2,
+                border: "2px solid #906aff",
+                backgroundColor: "#fff",
+                ".MuiOutlinedInput-notchedOutline": {
+                  border: "none",
+                },
+                "&:hover .MuiOutlinedInput-notchedOutline": {
+                  border: "none",
+                },
+                "& .MuiSelect-icon": {
+                  color: "#906aff",
+                },
+              }}
+            >
+              {roles.map((role) => (
+                <MenuItem key={role.value} value={role.value}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    {role.icon}
+                    {role.label}
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            fullWidth
+            variant="contained"
+            onClick={handleProceed}
+            sx={{
+              bgcolor: "#906aff",
+              color: "#fff",
+              fontWeight: "bold",
+              "&:hover": { bgcolor: "#ac8fff" },
+              borderRadius: 10,
+            }}
+          >
+            Proceed →
+          </Button>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default AccountTypeSelection;

--- a/src/pages/LoggedOut.tsx
+++ b/src/pages/LoggedOut.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+const LoggedOut: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        backgroundColor: "#f1ecff",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        flexDirection: "column",
+        textAlign: "center",
+        px: 2,
+      }}
+    >
+      <Typography
+        variant="h4"
+        mb={2}
+        sx={{ color: "#906aff", fontWeight: "bold" }}
+      >
+        You’ve been logged out
+      </Typography>
+
+      <Typography variant="body1" mb={4} sx={{ color: "#906aff" }}>
+        Click to return to the homepage
+      </Typography>
+
+      <Button
+        variant="contained"
+        onClick={() => navigate("/")}
+        sx={{
+          backgroundColor: "#906aff",
+          color: "#fff",
+          borderRadius: 8,
+          px: 4,
+          py: 1,
+          fontWeight: "bold",
+          textTransform: "none",
+          fontSize: "1rem",
+          "&:hover": {
+            backgroundColor: "#ac8fff",
+          },
+        }}
+      >
+        Return to Home
+      </Button>
+    </Box>
+  );
+};
+
+export default LoggedOut;

--- a/src/pages/LoggedOut.tsx
+++ b/src/pages/LoggedOut.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Typography, Button } from "@mui/material";
 import { useNavigate } from "react-router-dom";
+import { LoggedOutPage } from "../common/labelConstants";
 
 const LoggedOut: React.FC = () => {
   const navigate = useNavigate();
@@ -23,11 +24,11 @@ const LoggedOut: React.FC = () => {
         mb={2}
         sx={{ color: "#906aff", fontWeight: "bold" }}
       >
-        You’ve been logged out
+        {LoggedOutPage.TITLE}
       </Typography>
 
       <Typography variant="body1" mb={4} sx={{ color: "#906aff" }}>
-        Click to return to the homepage
+        {LoggedOutPage.DESCRIPTION}
       </Typography>
 
       <Button
@@ -47,7 +48,7 @@ const LoggedOut: React.FC = () => {
           },
         }}
       >
-        Return to Home
+        {LoggedOutPage.RETURN_HOME}
       </Button>
     </Box>
   );

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,10 +8,11 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
+    "esModuleInterop": true,
     "noEmit": true,
     "jsx": "react-jsx",
 


### PR DESCRIPTION
Added an account type selection screen to choose a role, plus a header at the top with a profile icon that opens a logout menu. Clicking logout shows a confirmation dialog, and if confirmed, it takes the user to a simple "Logged Out" page with a message and a button to return to the home screen.
<img width="1920" height="1080" alt="Screenshot (32)" src="https://github.com/user-attachments/assets/31580c09-b418-4034-84b5-ab0343be43aa" />
<img width="1920" height="1080" alt="Screenshot (33)" src="https://github.com/user-attachments/assets/e33cd537-9533-4a70-b903-0b0c623d3619" />
<img width="1920" height="1080" alt="Screenshot (34)" src="https://github.com/user-attachments/assets/7babc9da-ff39-4fa8-b273-5c15db6d0d77" />
<img width="1920" height="1080" alt="Screenshot (35)" src="https://github.com/user-attachments/assets/9388551d-c867-46e0-beef-be80ad5ad64b" />
